### PR TITLE
Add initial project structure with Flask app and Jupyter notebooks

### DIFF
--- a/Flask/flask/main.py
+++ b/Flask/flask/main.py
@@ -1,0 +1,23 @@
+from flask import Flask,render_template
+'''
+ It creates an instance of the Flask class, 
+ which will be your WSGI (Web Server Gateway Interface) application.
+'''
+###WSGI Application
+app=Flask(__name__)
+
+@app.route("/")
+def welcome():
+    return "<html><H1>Welcome to the flask course</H1></html>"
+
+@app.route("/index")
+def index():
+    return render_template('index.html')
+
+@app.route('/about')
+def about():
+    return render_template('about.html')
+
+
+if __name__=="__main__":
+    app.run(debug=True)

--- a/Flask/flask/templates/index.html
+++ b/Flask/flask/templates/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Flask App</title>
+</head>
+<body>
+    <h1>Welcome to My Flask App!</h1>
+    <p>This is a simple web application built with Flask.</p>
+</body>
+</html>

--- a/Flask/templates/index.html
+++ b/Flask/templates/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Flask App</title>
+</head>
+<body>
+    <h1>Welcome to My Flask App!</h1>
+    <p>This is a simple web application built with Flask.</p>
+</body>
+</html>

--- a/notebooks/1 AWS EC2 One-time Setup.ipynb
+++ b/notebooks/1 AWS EC2 One-time Setup.ipynb
@@ -1,0 +1,405 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## AWS EC2 with Boto3 Python Tutorial "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "https://boto3.amazonaws.com/v1/documentation/api/latest/guide/quickstart.html"
+   ]
+  },
+  {
+   "attachments": {
+    "image.png": {
+     "image/png": "iVBORw0KGgoAAAANSUhEUgAAAgAAAAEFCAIAAAAaP8iDAAAgAElEQVR4Ae2d/W8U17nH8z/gf6DY6o8X3ApVbQxEUa5UW6CoQhjJkYgEhkBUgfkFQcGOUhAYkAgBXcwt6VYKK6oYJ4oV2dBtWAfsCxaLTEiEsw7Y2CxrY0TUeLfQlFtp7iVPeTg7bztndl7OzHyjETlz5sx5+T7Hz2fOy8y+VNf5l7qujDeHh1l5VSXkAwWir4CG/6CAPwq85I3r//Fv7FD2jj+VRK5QILkK1HVlktt4tNxnBQAAnwVG9lCgNgUAgNr0w912CgAAdurgGhQIXQEAIHQTxLgC5gBY/+cvZ/72ZP2fv5SaIMIUUIw7CpoWlgIAQFjKJ6FccwC8nsrN/O3JoewdACAJnQBtVFkBAEBl60S9buYAqOvKjEx913h02P7Q4QEjgKj3BtRfQQUAAAWNEpsq2QHg7FjR6vh6rvT1XKn+QFZkAAAQm26BhqijAACgji3iVxM7AIjOXQzXH8jS+ECMrOvKAADx6x9oUegKAAChmyDGFZAGQP2B7Nmxoun6sBUAdJyo68pcu/e9lKbX7n1f15X58Pp9qbuQGArEQAEAIAZGVLYJbgDw9Vyp8eiw0a3bAODdzLcsweo/5n55/H/4FAEoAAVsFAAAbMTBpRoVkAZAXVem8ejwzN+euAbAh9fvi32a8+FhASWo68psOvcVDRd0IwC+hcYEdHX1H3MUv+ncVzWKgtuhgDoKiH8s6tQKNYmHAnYAOJS9Y3WMTH03MvUdO2IKuBgB/LR7iPz1u5lvuaPXdWVoxEA+/dq970UA6G7hq6v/mNM0TcwnHhZCKxKuAP9dJFwHNN8PBewA8HoqZ3843AWk4wR3aN1Q4KfdQ+9mvhUjye+zi//w+n2OIS3oFjFSDPuhF/KEAgErwH8vAZeL4pKggB0AjI7bPqbqCIC8M68H8FQPZ7vp3FfvZr79afcQS6+bAhLxoGnaL4//z6ZzX4lOXwxzJghAgegqAABE13bq1zxQAPAUDU33f3j9vujrSSzRxbM3pwBGAOr3J9TQcwUAAM8lRYasQNAAoMd23gVEcziappHfp0Vdd2sABBVmBrcQASgQaQUAgEibT/HKhwAA8tG8V4fnf4xTQ6aLwJqm8S3iLiAAQPGuhuq5UwAAcKcb7nKiQBAAcFIP0zS69QDTNIiEAvFWAACIt33DbZ1yAKDxAT/j88sB4cqE0qFAWAoAAGEpn4RylQNAEkRHG6GAcwUAAOdaIaWsAiYAWP/nLwfG57//x/8OjM9L/SSA1TZQ2TohPRSAAqwAAMBSIOC5AiYAqOvK1B/I8sGzMVUDAIDn5kGGUAAAQB/wTwFzAFT19aYJAAD/7IScE6sAAJBY0wfQcAAgAJFRBBRwrwAA4F473FlNgZfqOv9i9cU32fiRqe+qFYfrUAAKyCkAAMjphdQyCjwbAcikR1ooAAUCVQB/oYHKnbDCAICEGRzNjZoCAEDULBal+gIAUbIW6ppABQCABBo9sCYDAIFJjYKggBsFAAA3quEeZwoAAM50QiooEJICAEBIwieiWAAgEWZGI6OrAAAQXdupX3MAQH0boYaJVgAASLT5fW48AOCzwMgeCtSmAABQm364204BAMBOHVyDAqErAACEboIYVwAAiLFx0bQ4KAAAxMGKqrYBAFDVMqgXFPhRAQAAHcE/BQAA/7RFzlDAAwUAAA9ERBYWCgAAFsIgGgqooQAAoIYd4lkLACCedkWrYqMAABAbUyrYEABAQaOgSlDghQIAwAstEPJaAQDAa0WRHxTwVAEAwFM5kVmFAgBAhRw4gQKqKQAAqGaRONUHAIiTNdGWGCoAAMTQqMo0CQBQxhSoCBQwUwAAMFMFcd4oAAB4oyNygQI+KQAA+CQsstU0DQBAN4ACSisAAChtnohXDgCIuAFR/bgrAADE3cJhtg8ACFN9lA0FqioAAFSVCAlcKwAAuJYON0KBIBQAAIJQOall1ASAhu46HFAACpACPvkQAMAnYZFtrYvAHv7lvz98CPaAAtFVoKG7zqfKAwA+CYtsAQD0ASjgjQIAgDc6IpdgFVBlCggjgGDtjtI8VgAA8FhQZBeIAgBAIDKjkLgrAADE3cLxbB8AEE+7olUBKwAABCw4ivNEAQDAExmRSdIVAACS3gOi2X5fAPCzY/XvDx/KTAxkJgb+dO3Uyp7GqvuFsAYQzf6DWv9bAQAAXSGKCngPgNWpV0ZnRrZ+vP5nx+obuuveOPt64fuZnQO/tWcAABDF3oM6swIAAEuBQIQU8B4AmYmB1alXdO6eIlenXrEaDZgC4MrYjc+GvmA1i/PzvecvaJrWe/6CeFwZu8FpFsp/50vivZwAASjghwIAgB+qIk+/FfAYAG+cff394UM679/QXbeyp3HhH9+PzoxkJgZME5gCgDz+QvnvpMKN8W/I1/eev1Ccn2dpPhv6YuLutKZplJ4v3Rj/BgxglRDwVQEAwFd5kblPCngMgP2f79n68XoGwOrUK+8PH6IYmhFq6K7LTAwYxwGmANA07bOhL26Mf0ON//zKVXL0OgBcGbtBacTEdMtnQ18wD3xSENlCAU3TAAB0gygq4CUA3jj7+ujMiDj/QzM/Oo+/9eP14w++1q0KWAHgytiNz69cJWV7z1+g0YAOAHRKkz9w91HshTGoMwAQAyMmsAmeAcDo/f907RRN+xS+nxmdGeFhAQX6vjorMsAKADzvX5yfF0nAE/295y/Q4z8BgOeLEmhLNDlEBQCAEMVH0a4V8AwAmYkBnuQhFy/GiGEmwfiDrzlsBQCaBZq4O31j/BueC9KNALjxVvGcAAEo4JMCAIBPwiJbXxXwDADGZ/zMxMAbZ19fnXpldeoVUwCMzowwM2wAQLNAn1+5yk/3Vo7+8ytXGRKkGi8b+CoiMocCAAD6QBQV8AwAfV+d1S3tbv14/Z+uneKDH/Y50PfVWScAoFkgcT+PFQCwCyiKXTAedQYA4mHHpLXCMwBs/Xi9cRDAvt4Y2P/5HnE/qM0IgDb+i5v9rQDAO0FphUBkRtLsivYGrAAAELDgKM4TBTwDAL30O/7ga/oChM2/ozMjozMj+z/fw4//Dd119gDwpKnIBAr4pwAA4J+2yNk/BbwEAD/m/+xYvf3BKTkAAPhnY+QcgAIAQAAiowjPFfAFAOzWnQciAYCRu0NHvtjnyTF0J1P+oYTDhQL//NcPnv8Z1J4hAFC7hsgheAUAAAnNj3yxzznS7FMeuNg5X57F4UKB8g8lCZsFlRQACEpplOOlAgCAhJoAgAt/7fktAIBEl0VSKGCrAABgK0/lxaoAaHzvJ80fvNz8wcv2j/8N3XUYAbgGAwBQ2StxBgXcKwAASGhnD4Btn248dzN9YvjwgYudX87mfne+wwYDAAAA4LDn1XVlHKZEMiggq0CtAHh/+JAnx+jMiGzVg09vA4Dfne84cLGz8b2fsNM/cLHThgEAAADgsAMDAA6FQjIXCtQKABdFRvcWGwCkcifZ9XPg3M20iASOxxSQa+8/X57FFFB0/4JQc9UUAAAkLGIFgOYPXj4xfFj07xQ+cLFz7ZlmYzwAAAA473YYATjXCillFQAAJBSzAsDaM82msz3bPt244aNWAKAWd2+8FyMAiS6LpFDAVgEAwFaeyosBAEBHi9YzLUYPSDFDdy78/29tDt25ICagyFSuhwPiVddh07Kc55bK9TR01zlPb58SAKjslTiDAu4VAAAktDMCIJU7ee5m+kK+f2Rq6NzNtO4YmRrieJ1nt1oEbuiuS+V62AP+/FjD7/+6i0/FgKlT9tbvc3GmZfHVqgEAQKKTGZJiCsggCSI8UwAAkJDSCIBzN9M6z256akzmEACtZ1re/uRN0f9ymAKtZ1qoROIERRpHAFwrnbN++5M3+ZKYAw0snJTFFXj7kzc5c86T8qHTnx9r4AS1BDACkOiySAoFbBUAAGzlqbwYPABoQMCOeL48y2EKvPaHX8yXZ+kRe+jOBYrUAYCHEW9/8qY4p0SJyRdzmAKmADAtizL8/V938STPz481EAw4EiOAyn4kd4YRgJxeSC2jAAAgoVZVADS+95MDFztPDB9u+q//4Kfghu46qRGAeCN5UhunzPNFr/3hFzxWEAGgc77imoGYLT+Si5EcpoBpWTpU6Ioj9ugiuSx3AYwAJLoskkIBWwUAAFt5Ki9WBQDt+2z+4GWdx9ed2mwD1a0BiI/nOlfL3pnSOASAzueSaybkVJ0CYniIZelqJWZI2b79yZsAQGU/kjvDCEBOL6SWUQAAkFCrKgBGpobI6+k8vu7UQwDwUzk9a/OjOgccOl/GCQeM002mZRkBYJzrd1gHHZysTjECkOiySAoFbBUAAGzlqbxYFQAbPmq9kO9P5U5u+3SjOJNTIwDmy7MN3XX0hE7LtjzdT1Pw5GE5UpwConvJd7/9yZuid/79X3fxKfl98rlSZekAMF+e5SUHqlUq1wMAVPYjuTOMAOT0QmoZBQAACbWqAqChu27bpxuNL4XVDgBaUG3orjMCgEhDLp4f/DnAD/KUTPdYzXt4xKknqbKMACDkUHEELY7Rle7uFCMAiS6LpFDAVgEAwFaeyotOALDho1bd47/UIrA7n5iouwCAyl6JMyjgXgEAQEI7JwBYe6YZAPAVSACARJdFUihgqwAAYCtP5UUnABCn/jnsfArIV9cZj8wBgMpeiTMo4F4BAEBCOyMARqaGfne+o+pxId/PMKCA1ZvA8fDRvrYCAJDoskgKBWwVAABs5am8aATA2jPNGz5qrXoYPwoNALiGBABQ2StxBgXcKwAASGhnBIDuud75KQAAADjsedgG6lAoJHOhAAAgIRoA4Npre3gjRgASXRZJoYCtAgCArTyVF4fuZA5c7PTkuJDv99AnJiorAKCyV+IMCrhXAACQ0K78QylRrlbNxgIAEl0WSaGArQIAgK08lRcBABWQAABU9kqcQQH3CgAAEtoBAACAVXdp6K6zulRjPBaBaxQQt9soAADYiKO/BAAAAPo+8fwcAHiuBP4fJQVqAsDkssU4oAAUIAV8+rvHCMAnYZGtpmm1AiBRImIEgBGAVYefXLbY6lKN8QBAjQLidhsFAAAbcfSXAAAAQN8nnp8DAM+VwP+jpAAAIGEtAAAAsOouAICVMohXWQEAQMI6AAAAYNVdAAArZRCvsgIAgIR1AAAAwKq7AABWyiCeFCgU51Lp3mMnUyoco7kxqhUAINE/lQXAvezJ6b69xRsvPi8x93Bium/vdN/euYcT7LWLN/qn+/YWrqY5Zr48++9k93IcScnuZU9yjFIBNV8EAwAk/pCSlzSV7m1saqlfskKdo23jNuwCkuuJygJg8vja/OZF03172VPP3cvlNy/Kb14kAuBuuiO/edHd0xs52Xx5lpIV80McOd23N7950eTxtRyjVAAAkOu1SB22AgulMnn/xqaWVa0bQj8YRX39gxgBSPQOAEAFEgAAEl0WSRVQYDQ3Rg/+heKcAtV5VoVVrRvql6zYf/gEACBhEQAAALDqLpgCslIG8QyAhVJZ07SFUjmV7g3lYAJt6dhTv2TFzs6DAIBE/wQAAACxuzwuPZ3OL+SyDy71FyaXLb7UX7iVe/Sw+ERMU3sYL4LVrmG4OegAsLK5NcSVAGIAAOCmSwAAAICmadP5hcH01O51w+3LM21LB+jY+puLHG5bOnB0x/W+nglPYBBvABSKc/Rc7OYPMiL3iAAYz98m79/Y1BLwQeUeO5nSNA0AcNN3lAIALfzSEq7f/95+91cquH6qQ4hrALdyj3avG2ZHv3vd8NEd188cGR9MT40OzfX1TPT1TJzquimm2dc+eiv3yE1ve35P/ACwUCpnspd3dh6kmWh+HG5samnbuO3YyRTPVDzXINr/NwVA8G0ktQEA951JKQD47fR1+Yu7icKFQSgAmM4vnOq6Sa5/X/toX8/EdH7Bpic9Lj0dTE/tax+lW47uuO56NBAnAIzmxnROn72/LrClY09f/6CNwhG6BABEyFh2VVUQAIWr6WJ+yL+jcDVNJEgyAAbTUzTbs699NJd9YNdFDNdu5R5tb8kSBgbTU4br1SPiAYCFUnn/4RO8AZHc/crm1lWtG7Z07NnZebBt4zYjG1a1bgj+Sbm6SSRTAACSgqmaXEEAiPv3/XgwN32fwI+CnOcZ5AjgcenpmSPjbUsH2pdnBtNTj0tP3fXNS/0FYsCZI+OyOcQAAKO5MdH10zzPeP62qRR9/YPiMmljU0sme9k0ZVQiAYCoWKpKPUMEQOFqevL4WvGgB/PAACAWPXl8bYjvCQcJgKM7rpP3l33wN/ak6fwCDQX2tY8ar9rERB0A4/nb7P0bm1pS6V4nq76Z7GURA/sPn7CRSPFLAIDiBnJavRABQG/n6ubl85sXBQYAXdHiW8fOH949SRkYAPp6JtqWDuxeN+x6+l7XsR6XntL68Kmum7pLNqeRBkChOMfev23jNtn5nP2HT/DaQHQZAADYdO8oXQoRAPR9HvpuD/0b8AjgbrpDLF387pAnbt15JsEAYDA91bZ0YHtL1ivvTx39cekpjQMu9Rccdv3oAmChVOZp/VWtG5w8+Bs16esfZAZEdFkYADCaNZIxIQLA6B8DBkCiFoEfFp+0L8+0L89Y7eB8XHp6K/eor2di97rh7S3Z9uUZfg9ge0v2VNfNwfSUFTkeFp/QeoD9PiL+C4kuAI6dTJHvdu39SYRUupfyaWxqkR1DsIwhBgCAEMX3smgAwMih4GMCGAHQjk/TTTuPS0/7eiZ4Yw+tEOxeN7z1NxfFSN79afqkn8s+aFs64HAxIKIA4MmfxqYWq/Ve53+c9OJS/ZIVWzr2aJo2mhs7djK1qnXDyubWlc2tiu8ZBQCcG1rplABA8O7eWKLfALiVe0RT/8Y9P7dyj/jtX3rDy5jmYfFJLvuAZpAIA6e6bhqT0WKAk7XliAKAH//pzaMa/7AXSmVeE97SsYfXFXh2qH7JilWtG2onTY31NL0dADCVJXqRIQJg7uHE3L2ceAQ8BVTMD4mlhzgj5DcA6O0t4+QPrQnTkzvN3jwsPhlMT505Mr6vfXR0aO7ojuunum729UzwvYPpKRoWbG/J6rr7dH6B1hh08cbTKAJA/ACyV5M24mIA+30dCTwZbRhNUGMMAFCjgKrcHiIAsAuIhwK+AoD8sunkDM31k3O/lXu0r32URwNtSwd4DYCe+re3ZM8cGacHf0pm7MREGqulAk4fRQDwrL0nj/8khTgI0G0nFV8daGxqYekUCQAAihii1moAALwZNK7bQGnqpq9nwthX2pdn6EFeHArQNyEeFp+MDj371DvN//BHI2i7Jw0CjBnS22GmKw1i4igCgKfsvX2Hi7hi+mqYuOMole4VBQw9DACEbgJvKhAiAObLs89mgYQj4CmgZ/M/QulxnQKiN79Mn8oZAFZzRLpORgsJmqZZAeBx6SmtIetu1J1GEQA8X+/V/A9rMpobs8qzUJzjzUKcXoUAAKCCFTyoQ7gA4DkQCgQNAOG3hXU1CfjUvykg8si71w2b9hUdAIzrurq7qgKA2WCfVXQBEPxszM7Og8QAK0jobBTMKQAQjM6+lwIABOzrTYvzDwC0AGD1mq4fAKAPDdm/EBBFAJAXXtW6weZvcqFUppkiD2dseKFYqdeGAQCbbhClSwCAqUcOONI/ANAGUKvvtfkBAFpOsN8MGi0AjObGeAFgZXOr1Z83e39ChXMGbOnYs6Vjj5V/Z1dL2e4/fEKFoQDXaqFU5h+ECb5i+D0Aq97oND5EABSupu+mO8Qj4Ckgsei76Y5YfgrCflXWDwDYl0j9MioAGM/fZtdvPwLQeX8pBtjnrGmabmMo/fR58N5W9CkAgKhGhMMhAgDbQHmc4d8IgLYAmb67q2maHwCgV4J/u+6/X4rmf8Vikf6exU9+1i9Z0djUYvXDXqbe3zkDqgJgoVTu6x/UoUi3cahYLAap98pX/5OqjRFAhL2/pmkhAuDZCOD0RvEIegRQWXrhapo9csAB/wBA7thqX6YfAKARgBVy6K9F/RGA6P0bm1r6+getvvtm6v15y1D9khVV54KqAkB0Mfw6At3l4UsJYilVwxgBVJUoGglCBIDRyQYMgBD3fera7jcATF8C8GkEQGOOSK8B8Eu/9UtWtG3cZuX6NU0TvT8NEcgv7+w8yN+NqMoAKQCQWxFHA6F8TxQAiIZ/r1pLAEDni0M59Q8A9J3Oozuum/YEP0YA9MoYfzrCtFzFRwDsu+0/+anz/pnsZV4O3dl5UNM0zseeAS4AoMvc23fTTE2miwQAdIJE9RQACMXj6wr1DwD2b2b5AQCb9874j0RlAPDjf9WP8PBjOE/H6wDg0E27A4CYefBvJ5gCgBA4nr8d2IFdQPw35TIAAOh8cSin/gGA38xy8iaw/dtbmqZVfRHM/r0z7qMqA8D5vntyguz9NU0zAoDdtM1gwjUAnllk4za6PeCJIBEAC6Uy1SGsf2mVhXi8s/PgS7V0r8lli7mbJiEQIgCwC4hh4ysAaGO+6Tqw5yMAm+8OiX9NtfyFivn4EeZVVifzKqO5MTGZKQA0TbP/0eBaAJDJXqbb6UcF/BDENE8RAJqm8WAoeAasbG6lHbEAgKmlqkQCALTynN+8KK4fg7N5KvccADT/Y78AoGmaygBgX+Zio70VAOz/CGsBgKZpdHvbxm32pXh7VQcAWg8vFOeCP3iJHgBwY+IQATD3cKKYHxKPgHcBFW/0i6XP3cvxI3nAAV9HAJqmWf1Ui7cA4J+dqdoRVQYA7+Cs2gpjglAAQK+JBbwMwNM+mezl4J2+scTx/G1aD9h/+ASmgIw90zImRAAYnWzAAEjCNlAyvNVPtXgLAIefFFV8BMC/+W75N2N9wQkAFkpl3djCdATg/IfA6Habb1RY17emK0xKqoAi/47mxgAACbsCAEYOBR/j9whA0zSanNG9n8U/E09DBCeLwNtbsrdyj4yfg6Y3zqz2m+p6pMojgP2HT5Avc+6CuXVVAUA7R3X7i6g48TNz4/nbK5tbnczqcIni7VwfXwNUSUX8Pr2qTavBAICE3QGA4N29scQAAEAvBLQvz4jf6RR//6tt6YATANCvg+k++j+dX2CWOOl8KgOAN++P5sactEVMw+6Y3gMQL1GY6SIyQAcA0bFafSGOc+Y9S1YlckqfAoXiXGCbPu0L4sUAAEDC1iECoHijf7pvr3gEPAUkFj3dtzeWH4MTuwI9pLcvz7Cjv9RfOHNknA7TbULi7ZqmmaZ/XHpKAwgnOVCGKgOA99W4cKlVASD+yBczQASA6P1tdo6yXZgo4mYkvprMAAAgYfcQAYBtoDwUCGAEQH2CXtPdvW6YGSDRV8ySPi49pcklqy9Om92k9C4g8Xd6dZP1pm0RI6sCgHbL8DIDMYABIOv9eStOY1OLbFXFarsLL5TKx06mVrVuWNncqsKxpWMPiQAASBg0RAAUrqYnj68Vj4BHAGLRk8fX3sueZI8ccCAwAGiaRku121uy4lyQRI8Rkk7nF2gxYF/7qBRRVB4BaJrG8ypOZuEFPcxfBBMTUFg3DiAANDa18LKqk2f/hVKZ3wKrOlNkrEPtMbxfluqvwr8EQgBAwrghAsDoZAMGQHJ2Aek6BP1oV9vSAd2asC6Z/emt3CNaQjhzZFzK+yu+C4hazb5YigFORgCUv8gAnet06P3Z/zY2tfD0t73JPLzKP1a8s/NgKt0b+sErN6l0LwAgYWgFAVC4mn72c+2+HcX8EJEmsQDQNI1e2aVPO1R9b0vXn27lHtGkf/vyjPN5fzETxUcA4kcd6pesWNW6weEEi3MA6OaCmAFVvf9CqZzJXuafiBE/RCEq7HeYZ58cKuN3ffirGPgUhJzUCgKAvHMA/yYZAJqmTecXaEmgbenA0R3XB9NT9g/yj0tPL/UXyPW3LR3Y1z7qehJJfQBomsY+jrzzlo49x06mMtnLpgf5QR0AyFmbpqfvpunGAeT96fMSxrtS6d6dnQfZ9dcvWbGyuTWstV8Wx7/BRyZ7mX4ss+q/tGEXbwLLuX5KrRQAbr/7qwD8PhVx59CvjXNQYcUEuQag6yW8qZ/2dx7dcf1U182+nolL/YXRoblL/YXB9NSZI+O71w3zntF97aP2n/vXFWE8jQQAaBzAc0H8kG4aoC1DOgDwPInpLbRznxnAz/48s296F0fa/1CBUXNvYwIAgEMd6pesoF/FAQDcmFgpAMyXZ+ceTtBx59Cv6fs8HPNi6uZejiPvnt6Y37zo7umNHDP3cIJcfDE/xJF30x35zYsmj6/lGHUe/+fLsyECgDrNrdyjvp4JfronGGz9zUXe9U+TRX09E66f+sXeGRUA0ETNzs6D7HatAq4BQLJkspf5Udre8TU2tezsPOjiJTVR/9rDSgGA1sABADdmVQ0A/Aw+eXyt7gNtc/dy5NlF302e/e7pjXzjfHmWAcCRtOV08vhajlEqEDoAuOs8Lj29lXuUyz641F+YXLZ4MD2Vyz6Yzi+Yfk2a75INRAgA3LRM9nJf/+CxkynTg6ZiaGckzRQRPEwTU6TVT0ValZJK947nbzMnuGKhBAIAAK9yW0GX4zECcN8HAAAVSKAOAMSe5N+n0aMIAFEZhAMAwHj+dl//YNWDB08YAbjplgAAAGDVbwAAK2UQzwBQZxcQAOCmWwIAAIBVvwEArJRBPH8OurGpZVXrBhUOmhHq6x/EewAS/VNZABSupnXf55l7OEFf7xFdNiUrXE2LkZRMXCqg7w7pkom3hBvGFJBEl0VSNRTg96V5Lj70AO2MAgAkOoiyAAjXIwdcOgAg0WWRVBkFxvO3bVa5A77EiwEAgEQHAQAC9vWmxQEAEl0WSaGArQIAgK08lRcBAFOPHHAkAFDZK3EGBdwrAABIaAcABOzrTYsDACS6LJJCAVsFAABbeSovAgCmHjngSACgslfiDAq4VwAAkNAOAAjY15sWBwBIdFkkhdrKY+4AAAknSURBVAK2CgAAtvJUXgQATD1ywJEAQGWvxBkUcK8AACChHQAQsK83LQ4AkOiySAoFbBUAAGzlqbwIAJh65IAjAYDKXokzKOBeAQBAQjsAIGBfb1ocACDRZZEUCtgqAADYylN50SEAJpct5sPUhbmOnLuWmVy2+H7v6fu9pyeXLXadT6RvBAAqeyXOoIB7BQAACe2cAGDqtcaZXW+Rh53Z9ZZPbhoAkDBbIEnxMbhAZEYhHisAAEgIWhUA9IQ+dy3Dj9iTyxYX3nuHTnlYoEtA8c9+4evHB3y6ymHy9VNrXp1ctphHAHTL1GuNU6813u89PV+eLbz3zvSmNVzufHmWbpxctpg4NHctI2alqxJlwoWKlaFIykRsjlhWkGGMACS6LJJCAVsFAABbeSovVgXAfHmWPDU7ffaMPDIovPcODwumXmuklDO73pretMbU/5LXpmQMAIqcL8/O7HqLBhzTm9boCmVnPb1pDcFDzOpZVZ8PVqhKc9cyphWgyKk1rzJURIBxAwMLAACVvRJnUMC9AgCAhHZOAEAP4/ywT06Z/TV5SfL7ukgr/0vJxGGBuAZwv/c0ueap1xpFFyxmzm7dmBW7cqoSpzSOAGiIQITjOS6xxMDCAIBEl0VSKGCrAABgK0/lRYcAYFdIDpf9NVOBpmVEH023mPpfo9fmDOkueronDHDRhffeEZEgjgDI6etKn1rz6syut0wrIEYCAJU94sUZ1gBeaIFQdBQAACRsVRUAz9zuj1Ml7Ij5YV90x3RV54LFh24xXBUA05vWTG9ao3sqFzNnD27Mys0I4Pm0Fbcx4ABGABJdFkmhgK0CAICtPJUXqwJgvjzLM+88F0ROlqf7yQvTjArt6aSpfCIE365buaVMyJXrRgA0g89TNOyOOSvdGoDo9AkbvAYg1p8rQIXSCrOIEC4o4AAAUNkrcQYF3CsAAEho5wQA5EN5toe9rRjPq7XkWykxuVHyxcatOzoAcG40VjAOL3jBdnLZYisAcCbMIYaWWAEGANXTSBoAQNM0TAFJ/CEhqTIKAAASpnAIgIAdonEDqK4CuvUA3dWqpwQAkWRVb/E1AUYAEl0WSaGArQIAgK08lRcVBIA4eyO6XXFsQSvA4lWpMABQ2QvMzzACMNcFsWorAABI2EdBAEi58ngkxghAossiKRSwVQAAsJWn8iIAoAJCAIDKXokzKOBeAQBAQjsAAACw6i6YArJSBvEqKwAASFgHAAAArLoLAGClDOJVVqBWAPB+RwSgQMIV8OnvvK4r41POyBYK1ASAhu66RCmIEQBGAFYd3r+/BQDASnPE164AACChIQAAAFh1FwDAShnEq6wAACBhHQAAALDqLgCAlTKIV1kBAEDCOgAAAGDVXQAAK2UQr7ICAICEdQAAAMCquwAAVsogXmUFAAAJ6wAAAIBVdwEArJRBvMoKAAAS1gEAAACr7gIAWCmDeJUVAAAkrAMAAABW3QUAsFIG8SorAABIWAcAAACsugsAYKUM4lVWAACQsM4///VD+YcSjnAV+Oe/fpCwWVBJAYCglEY5XioAAHipJvJKrAIAQGJNH+mGAwCRNh8qr4oCAIAqlkA9ZBQAAGTUQlooYKEAAGAhDKKVVgAAUNo8qFxUFAAAomIp1FNUAAAQ1UAYCrhUAABwKRxuC1UBACBU+VF4XBQAAOJiyWS1AwBIlr3RWp8UAAB8EhbZ+qoAAOCrvMg8KQoAAEmxdLzaCQDEy55oTUgKAAAhCY9ia1IAAKhJPtwMBUgBAAA9IYoKAABRtBrqrJwCAIByJkGFHCgAADgQCUmgQDUFAIBqCuG6igoAACpaBXWKnAIAQORMhgprmgYAoBtAAQ8UAAA8EBFZBK4AABC45CgwjgoAAHG0avzbBADE38ZoYQAKAAABiIwiPFcAAPBcUmSYRAUAgCRaPfptBgCib0O0QAEFAAAFjIAqSCsAAEhLhhuggFEBAMCoCWLUV6BWADR01+GAAlAAAFDf2aGGRgVqAoAxO8RAASjgrQJ1XRlvM0RuUIAVAABYCgSggIoKAAAqWiUudQIA4mJJtCOmCgAAMTWsEs0CAJQwAyoBBawUAACslEF87QoAALVriByggI8KAAA+ipv4rAGAxHcBCKC2AgCA2vaJdu0AgGjbD7WPvQIAQOxNHGIDAYAQxUfRUKC6AgBAdY2Qwq0CAIBb5XAfFAhEAQAgEJkTWggAkFDDo9lRUQAAiIqlolhPACCKVkOdE6QAAJAgYwfeVAAgcMlRIBSQUQAAkFELaeUUAADk9EJqKBCwAgBAwIInqjgAIFHmRmOjpwAAED2bRafGAEB0bIWaJlIBACCRZg+o0QBAQEKjGCjgTgEAwJ1uuMuJAgCAE5WQBgqEpgAAEJr0CSgYAEiAkdHEKCsAAETZeqrXHQBQ3UKoX8IVAAAS3gF8bT4A4Ku8yBwK1KoAAFCrgrjfWgEAwFobXIECCigAAChghNhWAQCIrWnRsHgoAADEw45qtgIAUNMuqBUU+LcCAAC6gn8KAAD+aYucoYAHCgAAHoiILCwUAAAshEE0FFBDAQBADTvEsxYAQDztilbFRgEAIDamVLAhAICCRkGVoMALBQCAF1og5LUCAIDXiiI/KOCpAgCAp3IiswoFAIAKOXACBVRTAABQzSJxqg8AECdroi0xVAAAiKFRlWkSAKCMKVARKGCmAABgpgrivFEAAPBGR+QCBXxSAADwSVhkq2kaAIBuAAWUVgAAUNo8Ea8cABBxA6L6cVcAAIi7hcNsHwAQpvooGwpUVQAAqCoRErhWAABwLR1uhAJBKAAABKFyUssAAJJqebQ7IgoAABExVCSrCQBE0myodHIUAACSY+vgWwoABK85SoQCEgoAABJiIamkAgCApGBIDgWCVQAACFbvZJUGACTL3mht5BQAACJnsghVGACIkLFQ1SQqAAAk0epBtRkACEpplAMFXCkAALiSDTc5UgAAcCQTEkGBsBQAAMJSPgnlAgBJsDLaGGEFAIAIG0/5qgMAypsIFUy2AgBAsu3vb+sBAH/1Re5QoEYFAIAaBcTtNgoAADbi4BIUCF8BACB8G8S3BgBAfG2LlsVCAQAgFmZUtBHPAIADCkABlRVQ1HmgWtFX4P8AAvVPBkTQ+SgAAAAASUVORK5CYII="
+    }
+   },
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "![image.png](attachment:image.png)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Amazon Elastic Compute Cloud (Amazon EC2) is a web service that provides resizeable computing capacity in servers in Amazon's data centers—that you use to build and host your software systems."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Check if Instance is Present"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "No instance found with name mlops-prod\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "''"
+      ]
+     },
+     "execution_count": 1,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "import boto3\n",
+    "\n",
+    "ec2 = boto3.client('ec2')\n",
+    "\n",
+    "response = ec2.describe_instances()\n",
+    "\n",
+    "# instance_name = \"mlops-kgptalkie\"\n",
+    "\n",
+    "instance_name = \"mlops-prod\"\n",
+    "\n",
+    "instance_id=\"\" \n",
+    "\n",
+    "for resp in response['Reservations']:\n",
+    "    resp = resp['Instances'][0]\n",
+    "    tags = resp.get('Tags', [])\n",
+    "    \n",
+    "    for tag in tags:\n",
+    "        if tag.get(\"Key\", \"\")==\"Name\" and tag.get(\"Value\", \"\")==instance_name:\n",
+    "            instance_id = resp['InstanceId']\n",
+    "\n",
+    "if instance_id==\"\":\n",
+    "    print(f\"No instance found with name {instance_name}\")\n",
+    "    # raise(\"Stop here!!!\")\n",
+    "\n",
+    "instance_id"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Create an Amazon EC2 instance"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import boto3\n",
+    "\n",
+    "ec2 = boto3.client('ec2')\n",
+    "\n",
+    "if instance_id == \"\":\n",
+    "    response = ec2.run_instances(\n",
+    "        ImageId = 'ami-0197c13a4f68c9360',\n",
+    "        MinCount=1,\n",
+    "        MaxCount=1,\n",
+    "        InstanceType='t2.large',\n",
+    "        KeyName='kgptalkie',\n",
+    "        BlockDeviceMappings=[\n",
+    "            {\n",
+    "                \"DeviceName\": \"/dev/xvda\",\n",
+    "                'Ebs':{\n",
+    "                    'DeleteOnTermination': True,\n",
+    "                    'VolumeSize': 120\n",
+    "                }\n",
+    "            }\n",
+    "        ]\n",
+    "\n",
+    "    )\n",
+    "\n",
+    "    instance_id = response['Instances'][0]['InstanceId']\n",
+    "\n",
+    "    ec2.create_tags(Resources=[instance_id], Tags=[\n",
+    "        {\n",
+    "            'Key':'Name',\n",
+    "            'Value':instance_name\n",
+    "        }\n",
+    "    ])\n",
+    "\n",
+    "else:\n",
+    "    print(\"Instance is already present\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Create Security Group and add rules to it\n",
+    "- Security groups control inbound and outbound traffic of the EC2 instance network interface.\n",
+    "- every EC2 instance must have at least one Security Group associated with it. If no Security Group has been specified during the EC2 instance launch, the default Security Group of the default VPC is associated with the instance."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'sg-0d8128e8c17d8d1c4'"
+      ]
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "group_name = 'kgptalkie'\n",
+    "\n",
+    "response = ec2.describe_security_groups()\n",
+    "\n",
+    "security_group_id = [x['GroupId'] for x in response['SecurityGroups'] if x['GroupName']==group_name]\n",
+    "\n",
+    "if security_group_id == []:\n",
+    "    response = ec2.create_security_group(\n",
+    "        GroupName = group_name,\n",
+    "        Description = \"Security group for testing\"\n",
+    "    )\n",
+    "    security_group_id = response['GroupId']\n",
+    "else:\n",
+    "    security_group_id = security_group_id[0]\n",
+    "\n",
+    "security_group_id"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "This rule is already there\n",
+      "This rule is already there\n",
+      "This rule is already there\n",
+      "This rule is already there\n"
+     ]
+    }
+   ],
+   "source": [
+    "from botocore.exceptions import ClientError\n",
+    "\n",
+    "def update_security_group(group_id, protocol, port, cidr):\n",
+    "    try:\n",
+    "        response = ec2.authorize_security_group_ingress(\n",
+    "            GroupId = group_id,\n",
+    "            IpPermissions=[\n",
+    "                {\n",
+    "                    'IpProtocol': protocol,\n",
+    "                    'FromPort': port,\n",
+    "                    'ToPort': port,\n",
+    "                    'IpRanges': [{'CidrIp': cidr}]\n",
+    "                }\n",
+    "            ]\n",
+    "        )\n",
+    "    except ClientError as e:\n",
+    "        if e.response['Error']['Code']=='InvalidPermission.Duplicate':\n",
+    "            print('This rule is already there')\n",
+    "        else:\n",
+    "            print(\"an error as occured!\")\n",
+    "            print(e)\n",
+    "\n",
+    "update_security_group(security_group_id, 'tcp', 22, '0.0.0.0/0')\n",
+    "update_security_group(security_group_id, 'tcp', 80, '0.0.0.0/0')\n",
+    "update_security_group(security_group_id, 'tcp', 8501, '0.0.0.0/0')\n",
+    "update_security_group(security_group_id, 'tcp', 8502, '0.0.0.0/0')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'ResponseMetadata': {'RequestId': '3dbba900-ce97-4b4e-ba9e-24965a5b1792',\n",
+       "  'HTTPStatusCode': 200,\n",
+       "  'HTTPHeaders': {'x-amzn-requestid': '3dbba900-ce97-4b4e-ba9e-24965a5b1792',\n",
+       "   'cache-control': 'no-cache, no-store',\n",
+       "   'strict-transport-security': 'max-age=31536000; includeSubDomains',\n",
+       "   'content-type': 'text/xml;charset=UTF-8',\n",
+       "   'content-length': '247',\n",
+       "   'date': 'Wed, 07 Aug 2024 08:36:50 GMT',\n",
+       "   'server': 'AmazonEC2'},\n",
+       "  'RetryAttempts': 0}}"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "ec2.modify_instance_attribute(InstanceId=instance_id, Groups=[security_group_id])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Attach S3 Policy to EC2 Instance"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'IamInstanceProfileAssociation': {'AssociationId': 'iip-assoc-005620e6c249a116f',\n",
+       "  'InstanceId': 'i-00ce7804abca18c47',\n",
+       "  'IamInstanceProfile': {'Arn': 'arn:aws:iam::539320159019:instance-profile/ec2-s3-full-access',\n",
+       "   'Id': 'AIPAX3EP4RMVWCBMURPGY'},\n",
+       "  'State': 'associating'},\n",
+       " 'ResponseMetadata': {'RequestId': '3811198f-03fe-4b9f-9e39-838301d6de88',\n",
+       "  'HTTPStatusCode': 200,\n",
+       "  'HTTPHeaders': {'x-amzn-requestid': '3811198f-03fe-4b9f-9e39-838301d6de88',\n",
+       "   'cache-control': 'no-cache, no-store',\n",
+       "   'strict-transport-security': 'max-age=31536000; includeSubDomains',\n",
+       "   'vary': 'accept-encoding',\n",
+       "   'content-type': 'text/xml;charset=UTF-8',\n",
+       "   'transfer-encoding': 'chunked',\n",
+       "   'date': 'Wed, 07 Aug 2024 08:36:57 GMT',\n",
+       "   'server': 'AmazonEC2'},\n",
+       "  'RetryAttempts': 0}}"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# describe IAM role\n",
+    "iam = boto3.client('iam')\n",
+    "\n",
+    "role_name = \"ec2-s3-full-access\"\n",
+    "\n",
+    "response = iam.get_role(RoleName=role_name)\n",
+    "\n",
+    "role_arn = response['Role']['Arn']\n",
+    "\n",
+    "role_arn\n",
+    "\n",
+    "# Ensure there is an instance profile with the same name as the role\n",
+    "instance_profile_name = role_name\n",
+    "try:\n",
+    "    iam.get_instance_profile(InstanceProfileName=instance_profile_name)\n",
+    "except iam.exceptions.NoSuchEntityException:\n",
+    "    # Create an instance profile if it doesn't exist\n",
+    "    iam.create_instance_profile(InstanceProfileName=instance_profile_name)\n",
+    "    # Add role to the instance profile\n",
+    "    iam.add_role_to_instance_profile(\n",
+    "        InstanceProfileName=instance_profile_name,\n",
+    "        RoleName=role_name\n",
+    "    )\n",
+    "\n",
+    "# Attach the instance profile to the EC2 instance\n",
+    "ec2.associate_iam_instance_profile(\n",
+    "    IamInstanceProfile={\n",
+    "        'Name': instance_profile_name\n",
+    "    },\n",
+    "    InstanceId=instance_id\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Terminate"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import time\n",
+    "\n",
+    "def wait_for_status(instance_id, target_status):\n",
+    "    while True:\n",
+    "        response = ec2.describe_instances(InstanceIds=instance_id)\n",
+    "\n",
+    "        status = response['Reservations'][0]['Instances'][0]['State']['Name']\n",
+    "\n",
+    "        if status == target_status:\n",
+    "            print(\"Instance is in {} state\".format(target_status))\n",
+    "            break\n",
+    "        \n",
+    "        time.sleep(10)\n",
+    "\n",
+    "def terminate_instances(instance_id):\n",
+    "    print(\"EC2 Instance Termination\")\n",
+    "    ec2.terminate_instances(InstanceIds=instance_id)\n",
+    "\n",
+    "    wait_for_status(instance_id, 'terminated')\n",
+    "\n",
+    "# terminate_instances([instance_id])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.13"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/notebooks/2 AWS EC2 Periodic Setup.ipynb
+++ b/notebooks/2 AWS EC2 Periodic Setup.ipynb
@@ -1,0 +1,220 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## AWS EC2 with Boto3 Python Tutorial "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "https://boto3.amazonaws.com/v1/documentation/api/latest/guide/quickstart.html"
+   ]
+  },
+  {
+   "attachments": {
+    "image.png": {
+     "image/png": "iVBORw0KGgoAAAANSUhEUgAAAgAAAAEFCAIAAAAaP8iDAAAgAElEQVR4Ae2d/W8U17nH8z/gf6DY6o8X3ApVbQxEUa5UW6CoQhjJkYgEhkBUgfkFQcGOUhAYkAgBXcwt6VYKK6oYJ4oV2dBtWAfsCxaLTEiEsw7Y2CxrY0TUeLfQlFtp7iVPeTg7bztndl7OzHyjETlz5sx5+T7Hz2fOy8y+VNf5l7qujDeHh1l5VSXkAwWir4CG/6CAPwq85I3r//Fv7FD2jj+VRK5QILkK1HVlktt4tNxnBQAAnwVG9lCgNgUAgNr0w912CgAAdurgGhQIXQEAIHQTxLgC5gBY/+cvZ/72ZP2fv5SaIMIUUIw7CpoWlgIAQFjKJ6FccwC8nsrN/O3JoewdACAJnQBtVFkBAEBl60S9buYAqOvKjEx913h02P7Q4QEjgKj3BtRfQQUAAAWNEpsq2QHg7FjR6vh6rvT1XKn+QFZkAAAQm26BhqijAACgji3iVxM7AIjOXQzXH8jS+ECMrOvKAADx6x9oUegKAAChmyDGFZAGQP2B7Nmxoun6sBUAdJyo68pcu/e9lKbX7n1f15X58Pp9qbuQGArEQAEAIAZGVLYJbgDw9Vyp8eiw0a3bAODdzLcsweo/5n55/H/4FAEoAAVsFAAAbMTBpRoVkAZAXVem8ejwzN+euAbAh9fvi32a8+FhASWo68psOvcVDRd0IwC+hcYEdHX1H3MUv+ncVzWKgtuhgDoKiH8s6tQKNYmHAnYAOJS9Y3WMTH03MvUdO2IKuBgB/LR7iPz1u5lvuaPXdWVoxEA+/dq970UA6G7hq6v/mNM0TcwnHhZCKxKuAP9dJFwHNN8PBewA8HoqZ3843AWk4wR3aN1Q4KfdQ+9mvhUjye+zi//w+n2OIS3oFjFSDPuhF/KEAgErwH8vAZeL4pKggB0AjI7bPqbqCIC8M68H8FQPZ7vp3FfvZr79afcQS6+bAhLxoGnaL4//z6ZzX4lOXwxzJghAgegqAABE13bq1zxQAPAUDU33f3j9vujrSSzRxbM3pwBGAOr3J9TQcwUAAM8lRYasQNAAoMd23gVEcziappHfp0Vdd2sABBVmBrcQASgQaQUAgEibT/HKhwAA8tG8V4fnf4xTQ6aLwJqm8S3iLiAAQPGuhuq5UwAAcKcb7nKiQBAAcFIP0zS69QDTNIiEAvFWAACIt33DbZ1yAKDxAT/j88sB4cqE0qFAWAoAAGEpn4RylQNAEkRHG6GAcwUAAOdaIaWsAiYAWP/nLwfG57//x/8OjM9L/SSA1TZQ2TohPRSAAqwAAMBSIOC5AiYAqOvK1B/I8sGzMVUDAIDn5kGGUAAAQB/wTwFzAFT19aYJAAD/7IScE6sAAJBY0wfQcAAgAJFRBBRwrwAA4F473FlNgZfqOv9i9cU32fiRqe+qFYfrUAAKyCkAAMjphdQyCjwbAcikR1ooAAUCVQB/oYHKnbDCAICEGRzNjZoCAEDULBal+gIAUbIW6ppABQCABBo9sCYDAIFJjYKggBsFAAA3quEeZwoAAM50QiooEJICAEBIwieiWAAgEWZGI6OrAAAQXdupX3MAQH0boYaJVgAASLT5fW48AOCzwMgeCtSmAABQm364204BAMBOHVyDAqErAACEboIYVwAAiLFx0bQ4KAAAxMGKqrYBAFDVMqgXFPhRAQAAHcE/BQAA/7RFzlDAAwUAAA9ERBYWCgAAFsIgGgqooQAAoIYd4lkLACCedkWrYqMAABAbUyrYEABAQaOgSlDghQIAwAstEPJaAQDAa0WRHxTwVAEAwFM5kVmFAgBAhRw4gQKqKQAAqGaRONUHAIiTNdGWGCoAAMTQqMo0CQBQxhSoCBQwUwAAMFMFcd4oAAB4oyNygQI+KQAA+CQsstU0DQBAN4ACSisAAChtnohXDgCIuAFR/bgrAADE3cJhtg8ACFN9lA0FqioAAFSVCAlcKwAAuJYON0KBIBQAAIJQOall1ASAhu46HFAACpACPvkQAMAnYZFtrYvAHv7lvz98CPaAAtFVoKG7zqfKAwA+CYtsAQD0ASjgjQIAgDc6IpdgFVBlCggjgGDtjtI8VgAA8FhQZBeIAgBAIDKjkLgrAADE3cLxbB8AEE+7olUBKwAABCw4ivNEAQDAExmRSdIVAACS3gOi2X5fAPCzY/XvDx/KTAxkJgb+dO3Uyp7GqvuFsAYQzf6DWv9bAQAAXSGKCngPgNWpV0ZnRrZ+vP5nx+obuuveOPt64fuZnQO/tWcAABDF3oM6swIAAEuBQIQU8B4AmYmB1alXdO6eIlenXrEaDZgC4MrYjc+GvmA1i/PzvecvaJrWe/6CeFwZu8FpFsp/50vivZwAASjghwIAgB+qIk+/FfAYAG+cff394UM679/QXbeyp3HhH9+PzoxkJgZME5gCgDz+QvnvpMKN8W/I1/eev1Ccn2dpPhv6YuLutKZplJ4v3Rj/BgxglRDwVQEAwFd5kblPCngMgP2f79n68XoGwOrUK+8PH6IYmhFq6K7LTAwYxwGmANA07bOhL26Mf0ON//zKVXL0OgBcGbtBacTEdMtnQ18wD3xSENlCAU3TAAB0gygq4CUA3jj7+ujMiDj/QzM/Oo+/9eP14w++1q0KWAHgytiNz69cJWV7z1+g0YAOAHRKkz9w91HshTGoMwAQAyMmsAmeAcDo/f907RRN+xS+nxmdGeFhAQX6vjorMsAKADzvX5yfF0nAE/295y/Q4z8BgOeLEmhLNDlEBQCAEMVH0a4V8AwAmYkBnuQhFy/GiGEmwfiDrzlsBQCaBZq4O31j/BueC9KNALjxVvGcAAEo4JMCAIBPwiJbXxXwDADGZ/zMxMAbZ19fnXpldeoVUwCMzowwM2wAQLNAn1+5yk/3Vo7+8ytXGRKkGi8b+CoiMocCAAD6QBQV8AwAfV+d1S3tbv14/Z+uneKDH/Y50PfVWScAoFkgcT+PFQCwCyiKXTAedQYA4mHHpLXCMwBs/Xi9cRDAvt4Y2P/5HnE/qM0IgDb+i5v9rQDAO0FphUBkRtLsivYGrAAAELDgKM4TBTwDAL30O/7ga/oChM2/ozMjozMj+z/fw4//Dd119gDwpKnIBAr4pwAA4J+2yNk/BbwEAD/m/+xYvf3BKTkAAPhnY+QcgAIAQAAiowjPFfAFAOzWnQciAYCRu0NHvtjnyTF0J1P+oYTDhQL//NcPnv8Z1J4hAFC7hsgheAUAAAnNj3yxzznS7FMeuNg5X57F4UKB8g8lCZsFlRQACEpplOOlAgCAhJoAgAt/7fktAIBEl0VSKGCrAABgK0/lxaoAaHzvJ80fvNz8wcv2j/8N3XUYAbgGAwBQ2StxBgXcKwAASGhnD4Btn248dzN9YvjwgYudX87mfne+wwYDAAAA4LDn1XVlHKZEMiggq0CtAHh/+JAnx+jMiGzVg09vA4Dfne84cLGz8b2fsNM/cLHThgEAAADgsAMDAA6FQjIXCtQKABdFRvcWGwCkcifZ9XPg3M20iASOxxSQa+8/X57FFFB0/4JQc9UUAAAkLGIFgOYPXj4xfFj07xQ+cLFz7ZlmYzwAAAA473YYATjXCillFQAAJBSzAsDaM82msz3bPt244aNWAKAWd2+8FyMAiS6LpFDAVgEAwFaeyosBAEBHi9YzLUYPSDFDdy78/29tDt25ICagyFSuhwPiVddh07Kc55bK9TR01zlPb58SAKjslTiDAu4VAAAktDMCIJU7ee5m+kK+f2Rq6NzNtO4YmRrieJ1nt1oEbuiuS+V62AP+/FjD7/+6i0/FgKlT9tbvc3GmZfHVqgEAQKKTGZJiCsggCSI8UwAAkJDSCIBzN9M6z256akzmEACtZ1re/uRN0f9ymAKtZ1qoROIERRpHAFwrnbN++5M3+ZKYAw0snJTFFXj7kzc5c86T8qHTnx9r4AS1BDACkOiySAoFbBUAAGzlqbwYPABoQMCOeL48y2EKvPaHX8yXZ+kRe+jOBYrUAYCHEW9/8qY4p0SJyRdzmAKmADAtizL8/V938STPz481EAw4EiOAyn4kd4YRgJxeSC2jAAAgoVZVADS+95MDFztPDB9u+q//4Kfghu46qRGAeCN5UhunzPNFr/3hFzxWEAGgc77imoGYLT+Si5EcpoBpWTpU6Ioj9ugiuSx3AYwAJLoskkIBWwUAAFt5Ki9WBQDt+2z+4GWdx9ed2mwD1a0BiI/nOlfL3pnSOASAzueSaybkVJ0CYniIZelqJWZI2b79yZsAQGU/kjvDCEBOL6SWUQAAkFCrKgBGpobI6+k8vu7UQwDwUzk9a/OjOgccOl/GCQeM002mZRkBYJzrd1gHHZysTjECkOiySAoFbBUAAGzlqbxYFQAbPmq9kO9P5U5u+3SjOJNTIwDmy7MN3XX0hE7LtjzdT1Pw5GE5UpwConvJd7/9yZuid/79X3fxKfl98rlSZekAMF+e5SUHqlUq1wMAVPYjuTOMAOT0QmoZBQAACbWqAqChu27bpxuNL4XVDgBaUG3orjMCgEhDLp4f/DnAD/KUTPdYzXt4xKknqbKMACDkUHEELY7Rle7uFCMAiS6LpFDAVgEAwFaeyotOALDho1bd47/UIrA7n5iouwCAyl6JMyjgXgEAQEI7JwBYe6YZAPAVSACARJdFUihgqwAAYCtP5UUnABCn/jnsfArIV9cZj8wBgMpeiTMo4F4BAEBCOyMARqaGfne+o+pxId/PMKCA1ZvA8fDRvrYCAJDoskgKBWwVAABs5am8aATA2jPNGz5qrXoYPwoNALiGBABQ2StxBgXcKwAASGhnBIDuud75KQAAADjsedgG6lAoJHOhAAAgIRoA4Npre3gjRgASXRZJoYCtAgCArTyVF4fuZA5c7PTkuJDv99AnJiorAKCyV+IMCrhXAACQ0K78QylRrlbNxgIAEl0WSaGArQIAgK08lRcBABWQAABU9kqcQQH3CgAAEtoBAACAVXdp6K6zulRjPBaBaxQQt9soAADYiKO/BAAAAPo+8fwcAHiuBP4fJQVqAsDkssU4oAAUIAV8+rvHCMAnYZGtpmm1AiBRImIEgBGAVYefXLbY6lKN8QBAjQLidhsFAAAbcfSXAAAAQN8nnp8DAM+VwP+jpAAAIGEtAAAAsOouAICVMohXWQEAQMI6AAAAYNVdAAArZRCvsgIAgIR1AAAAwKq7AABWyiCeFCgU51Lp3mMnUyoco7kxqhUAINE/lQXAvezJ6b69xRsvPi8x93Bium/vdN/euYcT7LWLN/qn+/YWrqY5Zr48++9k93IcScnuZU9yjFIBNV8EAwAk/pCSlzSV7m1saqlfskKdo23jNuwCkuuJygJg8vja/OZF03172VPP3cvlNy/Kb14kAuBuuiO/edHd0xs52Xx5lpIV80McOd23N7950eTxtRyjVAAAkOu1SB22AgulMnn/xqaWVa0bQj8YRX39gxgBSPQOAEAFEgAAEl0WSRVQYDQ3Rg/+heKcAtV5VoVVrRvql6zYf/gEACBhEQAAALDqLpgCslIG8QyAhVJZ07SFUjmV7g3lYAJt6dhTv2TFzs6DAIBE/wQAAACxuzwuPZ3OL+SyDy71FyaXLb7UX7iVe/Sw+ERMU3sYL4LVrmG4OegAsLK5NcSVAGIAAOCmSwAAAICmadP5hcH01O51w+3LM21LB+jY+puLHG5bOnB0x/W+nglPYBBvABSKc/Rc7OYPMiL3iAAYz98m79/Y1BLwQeUeO5nSNA0AcNN3lAIALfzSEq7f/95+91cquH6qQ4hrALdyj3avG2ZHv3vd8NEd188cGR9MT40OzfX1TPT1TJzquimm2dc+eiv3yE1ve35P/ACwUCpnspd3dh6kmWh+HG5samnbuO3YyRTPVDzXINr/NwVA8G0ktQEA951JKQD47fR1+Yu7icKFQSgAmM4vnOq6Sa5/X/toX8/EdH7Bpic9Lj0dTE/tax+lW47uuO56NBAnAIzmxnROn72/LrClY09f/6CNwhG6BABEyFh2VVUQAIWr6WJ+yL+jcDVNJEgyAAbTUzTbs699NJd9YNdFDNdu5R5tb8kSBgbTU4br1SPiAYCFUnn/4RO8AZHc/crm1lWtG7Z07NnZebBt4zYjG1a1bgj+Sbm6SSRTAACSgqmaXEEAiPv3/XgwN32fwI+CnOcZ5AjgcenpmSPjbUsH2pdnBtNTj0tP3fXNS/0FYsCZI+OyOcQAAKO5MdH10zzPeP62qRR9/YPiMmljU0sme9k0ZVQiAYCoWKpKPUMEQOFqevL4WvGgB/PAACAWPXl8bYjvCQcJgKM7rpP3l33wN/ak6fwCDQX2tY8ar9rERB0A4/nb7P0bm1pS6V4nq76Z7GURA/sPn7CRSPFLAIDiBnJavRABQG/n6ubl85sXBQYAXdHiW8fOH949SRkYAPp6JtqWDuxeN+x6+l7XsR6XntL68Kmum7pLNqeRBkChOMfev23jNtn5nP2HT/DaQHQZAADYdO8oXQoRAPR9HvpuD/0b8AjgbrpDLF387pAnbt15JsEAYDA91bZ0YHtL1ivvTx39cekpjQMu9Rccdv3oAmChVOZp/VWtG5w8+Bs16esfZAZEdFkYADCaNZIxIQLA6B8DBkCiFoEfFp+0L8+0L89Y7eB8XHp6K/eor2di97rh7S3Z9uUZfg9ge0v2VNfNwfSUFTkeFp/QeoD9PiL+C4kuAI6dTJHvdu39SYRUupfyaWxqkR1DsIwhBgCAEMX3smgAwMih4GMCGAHQjk/TTTuPS0/7eiZ4Yw+tEOxeN7z1NxfFSN79afqkn8s+aFs64HAxIKIA4MmfxqYWq/Ve53+c9OJS/ZIVWzr2aJo2mhs7djK1qnXDyubWlc2tiu8ZBQCcG1rplABA8O7eWKLfALiVe0RT/8Y9P7dyj/jtX3rDy5jmYfFJLvuAZpAIA6e6bhqT0WKAk7XliAKAH//pzaMa/7AXSmVeE97SsYfXFXh2qH7JilWtG2onTY31NL0dADCVJXqRIQJg7uHE3L2ceAQ8BVTMD4mlhzgj5DcA6O0t4+QPrQnTkzvN3jwsPhlMT505Mr6vfXR0aO7ojuunum729UzwvYPpKRoWbG/J6rr7dH6B1hh08cbTKAJA/ACyV5M24mIA+30dCTwZbRhNUGMMAFCjgKrcHiIAsAuIhwK+AoD8sunkDM31k3O/lXu0r32URwNtSwd4DYCe+re3ZM8cGacHf0pm7MREGqulAk4fRQDwrL0nj/8khTgI0G0nFV8daGxqYekUCQAAihii1moAALwZNK7bQGnqpq9nwthX2pdn6EFeHArQNyEeFp+MDj371DvN//BHI2i7Jw0CjBnS22GmKw1i4igCgKfsvX2Hi7hi+mqYuOMole4VBQw9DACEbgJvKhAiAObLs89mgYQj4CmgZ/M/QulxnQKiN79Mn8oZAFZzRLpORgsJmqZZAeBx6SmtIetu1J1GEQA8X+/V/A9rMpobs8qzUJzjzUKcXoUAAKCCFTyoQ7gA4DkQCgQNAOG3hXU1CfjUvykg8si71w2b9hUdAIzrurq7qgKA2WCfVXQBEPxszM7Og8QAK0jobBTMKQAQjM6+lwIABOzrTYvzDwC0AGD1mq4fAKAPDdm/EBBFAJAXXtW6weZvcqFUppkiD2dseKFYqdeGAQCbbhClSwCAqUcOONI/ANAGUKvvtfkBAFpOsN8MGi0AjObGeAFgZXOr1Z83e39ChXMGbOnYs6Vjj5V/Z1dL2e4/fEKFoQDXaqFU5h+ECb5i+D0Aq97oND5EABSupu+mO8Qj4Ckgsei76Y5YfgrCflXWDwDYl0j9MioAGM/fZtdvPwLQeX8pBtjnrGmabmMo/fR58N5W9CkAgKhGhMMhAgDbQHmc4d8IgLYAmb67q2maHwCgV4J/u+6/X4rmf8Vikf6exU9+1i9Z0djUYvXDXqbe3zkDqgJgoVTu6x/UoUi3cahYLAap98pX/5OqjRFAhL2/pmkhAuDZCOD0RvEIegRQWXrhapo9csAB/wBA7thqX6YfAKARgBVy6K9F/RGA6P0bm1r6+getvvtm6v15y1D9khVV54KqAkB0Mfw6At3l4UsJYilVwxgBVJUoGglCBIDRyQYMgBD3fera7jcATF8C8GkEQGOOSK8B8Eu/9UtWtG3cZuX6NU0TvT8NEcgv7+w8yN+NqMoAKQCQWxFHA6F8TxQAiIZ/r1pLAEDni0M59Q8A9J3Oozuum/YEP0YA9MoYfzrCtFzFRwDsu+0/+anz/pnsZV4O3dl5UNM0zseeAS4AoMvc23fTTE2miwQAdIJE9RQACMXj6wr1DwD2b2b5AQCb9874j0RlAPDjf9WP8PBjOE/H6wDg0E27A4CYefBvJ5gCgBA4nr8d2IFdQPw35TIAAOh8cSin/gGA38xy8iaw/dtbmqZVfRHM/r0z7qMqA8D5vntyguz9NU0zAoDdtM1gwjUAnllk4za6PeCJIBEAC6Uy1SGsf2mVhXi8s/PgS7V0r8lli7mbJiEQIgCwC4hh4ysAaGO+6Tqw5yMAm+8OiX9NtfyFivn4EeZVVifzKqO5MTGZKQA0TbP/0eBaAJDJXqbb6UcF/BDENE8RAJqm8WAoeAasbG6lHbEAgKmlqkQCALTynN+8KK4fg7N5KvccADT/Y78AoGmaygBgX+Zio70VAOz/CGsBgKZpdHvbxm32pXh7VQcAWg8vFOeCP3iJHgBwY+IQATD3cKKYHxKPgHcBFW/0i6XP3cvxI3nAAV9HAJqmWf1Ui7cA4J+dqdoRVQYA7+Cs2gpjglAAQK+JBbwMwNM+mezl4J2+scTx/G1aD9h/+ASmgIw90zImRAAYnWzAAEjCNlAyvNVPtXgLAIefFFV8BMC/+W75N2N9wQkAFkpl3djCdATg/IfA6Habb1RY17emK0xKqoAi/47mxgAACbsCAEYOBR/j9whA0zSanNG9n8U/E09DBCeLwNtbsrdyj4yfg6Y3zqz2m+p6pMojgP2HT5Avc+6CuXVVAUA7R3X7i6g48TNz4/nbK5tbnczqcIni7VwfXwNUSUX8Pr2qTavBAICE3QGA4N29scQAAEAvBLQvz4jf6RR//6tt6YATANCvg+k++j+dX2CWOOl8KgOAN++P5sactEVMw+6Y3gMQL1GY6SIyQAcA0bFafSGOc+Y9S1YlckqfAoXiXGCbPu0L4sUAAEDC1iECoHijf7pvr3gEPAUkFj3dtzeWH4MTuwI9pLcvz7Cjv9RfOHNknA7TbULi7ZqmmaZ/XHpKAwgnOVCGKgOA99W4cKlVASD+yBczQASA6P1tdo6yXZgo4mYkvprMAAAgYfcQAYBtoDwUCGAEQH2CXtPdvW6YGSDRV8ySPi49pcklqy9Om92k9C4g8Xd6dZP1pm0RI6sCgHbL8DIDMYABIOv9eStOY1OLbFXFarsLL5TKx06mVrVuWNncqsKxpWMPiQAASBg0RAAUrqYnj68Vj4BHAGLRk8fX3sueZI8ccCAwAGiaRku121uy4lyQRI8Rkk7nF2gxYF/7qBRRVB4BaJrG8ypOZuEFPcxfBBMTUFg3DiAANDa18LKqk2f/hVKZ3wKrOlNkrEPtMbxfluqvwr8EQgBAwrghAsDoZAMGQHJ2Aek6BP1oV9vSAd2asC6Z/emt3CNaQjhzZFzK+yu+C4hazb5YigFORgCUv8gAnet06P3Z/zY2tfD0t73JPLzKP1a8s/NgKt0b+sErN6l0LwAgYWgFAVC4mn72c+2+HcX8EJEmsQDQNI1e2aVPO1R9b0vXn27lHtGkf/vyjPN5fzETxUcA4kcd6pesWNW6weEEi3MA6OaCmAFVvf9CqZzJXuafiBE/RCEq7HeYZ58cKuN3ffirGPgUhJzUCgKAvHMA/yYZAJqmTecXaEmgbenA0R3XB9NT9g/yj0tPL/UXyPW3LR3Y1z7qehJJfQBomsY+jrzzlo49x06mMtnLpgf5QR0AyFmbpqfvpunGAeT96fMSxrtS6d6dnQfZ9dcvWbGyuTWstV8Wx7/BRyZ7mX4ss+q/tGEXbwLLuX5KrRQAbr/7qwD8PhVx59CvjXNQYcUEuQag6yW8qZ/2dx7dcf1U182+nolL/YXRoblL/YXB9NSZI+O71w3zntF97aP2n/vXFWE8jQQAaBzAc0H8kG4aoC1DOgDwPInpLbRznxnAz/48s296F0fa/1CBUXNvYwIAgEMd6pesoF/FAQDcmFgpAMyXZ+ceTtBx59Cv6fs8HPNi6uZejiPvnt6Y37zo7umNHDP3cIJcfDE/xJF30x35zYsmj6/lGHUe/+fLsyECgDrNrdyjvp4JfronGGz9zUXe9U+TRX09E66f+sXeGRUA0ETNzs6D7HatAq4BQLJkspf5Udre8TU2tezsPOjiJTVR/9rDSgGA1sABADdmVQ0A/Aw+eXyt7gNtc/dy5NlF302e/e7pjXzjfHmWAcCRtOV08vhajlEqEDoAuOs8Lj29lXuUyz641F+YXLZ4MD2Vyz6Yzi+Yfk2a75INRAgA3LRM9nJf/+CxkynTg6ZiaGckzRQRPEwTU6TVT0ValZJK947nbzMnuGKhBAIAAK9yW0GX4zECcN8HAAAVSKAOAMSe5N+n0aMIAFEZhAMAwHj+dl//YNWDB08YAbjplgAAAGDVbwAAK2UQzwBQZxcQAOCmWwIAAIBVvwEArJRBPH8OurGpZVXrBhUOmhHq6x/EewAS/VNZABSupnXf55l7OEFf7xFdNiUrXE2LkZRMXCqg7w7pkom3hBvGFJBEl0VSNRTg96V5Lj70AO2MAgAkOoiyAAjXIwdcOgAg0WWRVBkFxvO3bVa5A77EiwEAgEQHAQAC9vWmxQEAEl0WSaGArQIAgK08lRcBAFOPHHAkAFDZK3EGBdwrAABIaAcABOzrTYsDACS6LJJCAVsFAABbeSovAgCmHjngSACgslfiDAq4VwAAkNAOAAjY15sWBwBIdFkkhdrKY+4AAAknSURBVAK2CgAAtvJUXgQATD1ywJEAQGWvxBkUcK8AACChHQAQsK83LQ4AkOiySAoFbBUAAGzlqbwIAJh65IAjAYDKXokzKOBeAQBAQjsAIGBfb1ocACDRZZEUCtgqAADYylN50SEAJpct5sPUhbmOnLuWmVy2+H7v6fu9pyeXLXadT6RvBAAqeyXOoIB7BQAACe2cAGDqtcaZXW+Rh53Z9ZZPbhoAkDBbIEnxMbhAZEYhHisAAEgIWhUA9IQ+dy3Dj9iTyxYX3nuHTnlYoEtA8c9+4evHB3y6ymHy9VNrXp1ctphHAHTL1GuNU6813u89PV+eLbz3zvSmNVzufHmWbpxctpg4NHctI2alqxJlwoWKlaFIykRsjlhWkGGMACS6LJJCAVsFAABbeSovVgXAfHmWPDU7ffaMPDIovPcODwumXmuklDO73pretMbU/5LXpmQMAIqcL8/O7HqLBhzTm9boCmVnPb1pDcFDzOpZVZ8PVqhKc9cyphWgyKk1rzJURIBxAwMLAACVvRJnUMC9AgCAhHZOAEAP4/ywT06Z/TV5SfL7ukgr/0vJxGGBuAZwv/c0ueap1xpFFyxmzm7dmBW7cqoSpzSOAGiIQITjOS6xxMDCAIBEl0VSKGCrAABgK0/lRYcAYFdIDpf9NVOBpmVEH023mPpfo9fmDOkueronDHDRhffeEZEgjgDI6etKn1rz6syut0wrIEYCAJU94sUZ1gBeaIFQdBQAACRsVRUAz9zuj1Ml7Ij5YV90x3RV54LFh24xXBUA05vWTG9ao3sqFzNnD27Mys0I4Pm0Fbcx4ABGABJdFkmhgK0CAICtPJUXqwJgvjzLM+88F0ROlqf7yQvTjArt6aSpfCIE365buaVMyJXrRgA0g89TNOyOOSvdGoDo9AkbvAYg1p8rQIXSCrOIEC4o4AAAUNkrcQYF3CsAAEho5wQA5EN5toe9rRjPq7XkWykxuVHyxcatOzoAcG40VjAOL3jBdnLZYisAcCbMIYaWWAEGANXTSBoAQNM0TAFJ/CEhqTIKAAASpnAIgIAdonEDqK4CuvUA3dWqpwQAkWRVb/E1AUYAEl0WSaGArQIAgK08lRcVBIA4eyO6XXFsQSvA4lWpMABQ2QvMzzACMNcFsWorAABI2EdBAEi58ngkxghAossiKRSwVQAAsJWn8iIAoAJCAIDKXokzKOBeAQBAQjsAAACw6i6YArJSBvEqKwAASFgHAAAArLoLAGClDOJVVqBWAPB+RwSgQMIV8OnvvK4r41POyBYK1ASAhu66RCmIEQBGAFYd3r+/BQDASnPE164AACChIQAAAFh1FwDAShnEq6wAACBhHQAAALDqLgCAlTKIV1kBAEDCOgAAAGDVXQAAK2UQr7ICAICEdQAAAMCquwAAVsogXmUFAAAJ6wAAAIBVdwEArJRBvMoKAAAS1gEAAACr7gIAWCmDeJUVAAAkrAMAAABW3QUAsFIG8SorAABIWAcAAACsugsAYKUM4lVWAACQsM4///VD+YcSjnAV+Oe/fpCwWVBJAYCglEY5XioAAHipJvJKrAIAQGJNH+mGAwCRNh8qr4oCAIAqlkA9ZBQAAGTUQlooYKEAAGAhDKKVVgAAUNo8qFxUFAAAomIp1FNUAAAQ1UAYCrhUAABwKRxuC1UBACBU+VF4XBQAAOJiyWS1AwBIlr3RWp8UAAB8EhbZ+qoAAOCrvMg8KQoAAEmxdLzaCQDEy55oTUgKAAAhCY9ia1IAAKhJPtwMBUgBAAA9IYoKAABRtBrqrJwCAIByJkGFHCgAADgQCUmgQDUFAIBqCuG6igoAACpaBXWKnAIAQORMhgprmgYAoBtAAQ8UAAA8EBFZBK4AABC45CgwjgoAAHG0avzbBADE38ZoYQAKAAABiIwiPFcAAPBcUmSYRAUAgCRaPfptBgCib0O0QAEFAAAFjIAqSCsAAEhLhhuggFEBAMCoCWLUV6BWADR01+GAAlAAAFDf2aGGRgVqAoAxO8RAASjgrQJ1XRlvM0RuUIAVAABYCgSggIoKAAAqWiUudQIA4mJJtCOmCgAAMTWsEs0CAJQwAyoBBawUAACslEF87QoAALVriByggI8KAAA+ipv4rAGAxHcBCKC2AgCA2vaJdu0AgGjbD7WPvQIAQOxNHGIDAYAQxUfRUKC6AgBAdY2Qwq0CAIBb5XAfFAhEAQAgEJkTWggAkFDDo9lRUQAAiIqlolhPACCKVkOdE6QAAJAgYwfeVAAgcMlRIBSQUQAAkFELaeUUAADk9EJqKBCwAgBAwIInqjgAIFHmRmOjpwAAED2bRafGAEB0bIWaJlIBACCRZg+o0QBAQEKjGCjgTgEAwJ1uuMuJAgCAE5WQBgqEpgAAEJr0CSgYAEiAkdHEKCsAAETZeqrXHQBQ3UKoX8IVAAAS3gF8bT4A4Ku8yBwK1KoAAFCrgrjfWgEAwFobXIECCigAAChghNhWAQCIrWnRsHgoAADEw45qtgIAUNMuqBUU+LcCAAC6gn8KAAD+aYucoYAHCgAAHoiILCwUAAAshEE0FFBDAQBADTvEsxYAQDztilbFRgEAIDamVLAhAICCRkGVoMALBQCAF1og5LUCAIDXiiI/KOCpAgCAp3IiswoFAIAKOXACBVRTAABQzSJxqg8AECdroi0xVAAAiKFRlWkSAKCMKVARKGCmAABgpgrivFEAAPBGR+QCBXxSAADwSVhkq2kaAIBuAAWUVgAAUNo8Ea8cABBxA6L6cVcAAIi7hcNsHwAQpvooGwpUVQAAqCoRErhWAABwLR1uhAJBKAAABKFyUssAAJJqebQ7IgoAABExVCSrCQBE0myodHIUAACSY+vgWwoABK85SoQCEgoAABJiIamkAgCApGBIDgWCVQAACFbvZJUGACTL3mht5BQAACJnsghVGACIkLFQ1SQqAAAk0epBtRkACEpplAMFXCkAALiSDTc5UgAAcCQTEkGBsBQAAMJSPgnlAgBJsDLaGGEFAIAIG0/5qgMAypsIFUy2AgBAsu3vb+sBAH/1Re5QoEYFAIAaBcTtNgoAADbi4BIUCF8BACB8G8S3BgBAfG2LlsVCAQAgFmZUtBHPAIADCkABlRVQ1HmgWtFX4P8AAvVPBkTQ+SgAAAAASUVORK5CYII="
+    }
+   },
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "![image.png](attachment:image.png)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Amazon Elastic Compute Cloud (Amazon EC2) is a web service that provides resizeable computing capacity in servers in Amazon's data centers—that you use to build and host your software systems."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Start, Stop and Delete Amazon EC2 instances"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'i-0aa08b36530f25156'"
+      ]
+     },
+     "execution_count": 2,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "import boto3\n",
+    "\n",
+    "ec2 = boto3.client('ec2')\n",
+    "\n",
+    "response = ec2.describe_instances()\n",
+    "\n",
+    "# instance_name = \"mlops-kgptalkie\"\n",
+    "instance_name = \"mlops-prod\"\n",
+    "instance_id=\"\" \n",
+    "\n",
+    "for resp in response['Reservations']:\n",
+    "    resp = resp['Instances'][0]\n",
+    "    tags = resp.get('Tags', [])\n",
+    "    \n",
+    "    for tag in tags:\n",
+    "        if tag.get(\"Key\", \"\")==\"Name\" and tag.get(\"Value\", \"\")==instance_name:\n",
+    "            instance_id = resp['InstanceId']\n",
+    "\n",
+    "if instance_id==\"\":\n",
+    "    print(f\"No instance found with name {instance_name}\")\n",
+    "    raise(\"Stop here!!!\")\n",
+    "\n",
+    "instance_id"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# status -> running, stopped, terminated, pending etc.\n",
+    "\n",
+    "import time\n",
+    "\n",
+    "def wait_for_status(instance_id, target_status):\n",
+    "    while True:\n",
+    "        response = ec2.describe_instances(InstanceIds=instance_id)\n",
+    "\n",
+    "        status = response['Reservations'][0]['Instances'][0]['State']['Name']\n",
+    "\n",
+    "        if status == target_status:\n",
+    "            print(\"Instance is in {} state\".format(target_status))\n",
+    "            break\n",
+    "        \n",
+    "        time.sleep(10)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "EC2 Instance Stop\n",
+      "Instance is in stopped state\n"
+     ]
+    }
+   ],
+   "source": [
+    "def stop_instances(instance_id):\n",
+    "    print(\"EC2 Instance Stop\")\n",
+    "    ec2.stop_instances(InstanceIds=instance_id)\n",
+    "\n",
+    "    wait_for_status(instance_id, 'stopped')\n",
+    "\n",
+    "stop_instances([instance_id])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "EC2 Instance Start\n",
+      "Instance is in running state\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "'54.163.207.194'"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "def start_instances(instance_id):\n",
+    "    print(\"EC2 Instance Start\")\n",
+    "    ec2.start_instances(InstanceIds=instance_id)\n",
+    "\n",
+    "    wait_for_status(instance_id, 'running')\n",
+    "\n",
+    "start_instances([instance_id])\n",
+    "\n",
+    "response = ec2.describe_instances(InstanceIds=[instance_id])\n",
+    "public_ip = response['Reservations'][0]['Instances'][0]['PublicIpAddress']\n",
+    "public_ip"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.13"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}


### PR DESCRIPTION
### Summary

This pull request introduces the initial structure for the `ML Ops on AWS` project, including:

- A basic Flask web application (`app.py`, `main.py`)
- Organized project folders for backend and templates
- Example HTML templates for testing Flask routing
- A new `/notebooks` directory with initial Jupyter notebooks for ML experimentation
- GitHub Actions workflow file for Python CI (can be extended for testing & linting)

### Features

- Flask app structured for scalability
- Notebooks folder for ML lifecycle development
- Workflow pipeline foundation (`.github/workflows/python-app.yml`)

### Motivation

The goal of this commit is to lay a solid foundation for developing an ML operations pipeline on AWS, including:

- Web interface/API layer via Flask
- Jupyter notebook experimentation
- GitHub Actions for CI/CD

This will serve as the base for further integration with AWS services and MLOps practices.

---